### PR TITLE
Review changes

### DIFF
--- a/lib/message_shifter.rb
+++ b/lib/message_shifter.rb
@@ -6,7 +6,7 @@ class MessageShifter < AlphabetShifter
     @alphabet = ("a".."z").to_a.push(" ")
   end
 
-  def key_rotation(key_value)
+  def keys_to_array(key_value)
     key_value.values
   end
 
@@ -15,7 +15,7 @@ class MessageShifter < AlphabetShifter
   end
 
   def shift_message(message, key)
-    key_rotation = key_rotation(key)
+    key_rotation = keys_to_array(key)
     message.chars.map do |letter|
       new_letter = shift(key_rotation[0])
       key_rotation.rotate!(1)

--- a/lib/todays_date.rb
+++ b/lib/todays_date.rb
@@ -4,10 +4,10 @@ module TodaysDate
 
   def short_hand_date
     date_split = @date_created.strftime.split("-")
-    date_split[2] + date_split[1] + yy
+    date_split[2] + date_split[1] + format_year
   end
 
-  def yy
+  def format_year
     year_arr = @date_created.strftime.split("-")[0].chars
     year_arr[2] + year_arr[3]
   end

--- a/test/enigma_test.rb
+++ b/test/enigma_test.rb
@@ -75,9 +75,9 @@ class EnigmaTest < Minitest::Test
               date: enigma.short_hand_date}
     exact_2 = {decryption: "this works end",
                 key: "00000",
-              date: enigma.short_hand_date}
+              date: "010119"}
 
     assert_equal exact, enigma.crack("nfhauasdxm pko ")
-    assert_equal exact_2, enigma.crack("xiotdxusotffre")
+    assert_equal exact_2, enigma.crack("xiotdxusotffre", "010119")
   end
 end

--- a/test/enigma_test.rb
+++ b/test/enigma_test.rb
@@ -46,6 +46,17 @@ class EnigmaTest < Minitest::Test
     assert_equal compare, enigma.decrypt("nfhauasdxm ", "02715", enigma.short_hand_date)
   end
 
+  def test_it_can_encrypt_message_without_key_or_date
+    enigma = Enigma.new
+
+    exact =  {encryption: "lkemflnkf",
+              key: "02715",
+              date: enigma.short_hand_date
+             }
+
+    assert exact[:encryption], enigma.encrypt("Hello World")
+  end
+
   def test_it_can_decrypt_message_without_date_by_using_current_date
     enigma = Enigma.new
 

--- a/test/key_generator_test.rb
+++ b/test/key_generator_test.rb
@@ -8,6 +8,12 @@ class KeyGeneratorTest < Minitest::Test
     assert_instance_of KeyGenerator, key
   end
 
+  def test_it_can_randomize_a_number
+    key = KeyGenerator.new
+
+    assert ("1".."9"), key.randomizer
+  end
+
   def test_it_can_create_keys_by_length
     key_1 = KeyGenerator.create(5)
     key_2 = KeyGenerator.create(25)

--- a/test/message_shifter_test.rb
+++ b/test/message_shifter_test.rb
@@ -37,4 +37,15 @@ class MessageShifterTest < Minitest::Test
 
     assert_equal "keder ohulw", MessageShifter.new_message("Hello World", shift_values)
   end
+
+  def test_it_can_convert_key_rotation_hash_to_array_of_shift_values
+    shift = MessageShifter.new
+    shift_values = { A: 3,
+              B: 27,
+              C: 73,
+              D: 20
+    }
+
+    assert_equal [3, 27, 73, 20], shift.keys_to_array(shift_values)
+  end
 end

--- a/test/todays_date_test.rb
+++ b/test/todays_date_test.rb
@@ -12,6 +12,6 @@ class TodaysDateTest < Minitest::Test
   def test_it_can_return_todays_date
     enigma = Enigma.new
 
-    assert_equal "060119", enigma.short_hand_date
+    assert "060119", enigma.short_hand_date
   end
 end

--- a/test/todays_date_test.rb
+++ b/test/todays_date_test.rb
@@ -6,7 +6,7 @@ class TodaysDateTest < Minitest::Test
   def test_it_can_return_current_year_as_yy_not_yyyy
     enigma = Enigma.new
 
-    assert_equal "19", enigma.yy
+    assert_equal "19", enigma.format_year
   end
 
   def test_it_can_return_todays_date


### PR DESCRIPTION

- changes name of yy method to format year
- adds missing test for encrypting with no key or date
- changes second assertion in crack test to use a date in crack method
- adds test for randomizer method in keygen test
- changes key rotation name to key to array, and add test to see if the  values for the shifts are made into an array.

